### PR TITLE
Move pyserini import under is_pyserini_available to prevent `ImportError` bugs when developing

### DIFF
--- a/verifiers/tools/local_wiki_search.py
+++ b/verifiers/tools/local_wiki_search.py
@@ -1,17 +1,36 @@
 import os
 
 
-os.environ["JAVA_OPTS"] = "-Xms16g -Xmx32g " "-XX:MaxDirectMemorySize=16g "
+def is_pyserini_available():
+    try:
+        import pyserini
 
-from pyserini.search.lucene import LuceneSearcher
-import json
+        return True
+    except ImportError:
+        return False
 
 
-_searcher = LuceneSearcher.from_prebuilt_index("wikipedia-kilt-doc")
+if is_pyserini_available():
+    os.environ["JAVA_OPTS"] = "-Xms16g -Xmx32g " "-XX:MaxDirectMemorySize=16g "
+
+    try:
+        from pyserini.search.lucene import LuceneSearcher
+        import json
+
+        _searcher = LuceneSearcher.from_prebuilt_index("wikipedia-kilt-doc")
+        PYSERINI_LOADED = True
+    except Exception as e:
+        print(f"Warning: Failed to initialize Pyserini searcher: {e}")
+        PYSERINI_LOADED = False
+else:
+    PYSERINI_LOADED = False
 
 
 def wiki_search(query: str) -> str:
     """Searches Wikipedia and returns the top matching article content."""
+
+    if not PYSERINI_LOADED:
+        return "Error: Pyserini is not available or failed to initialize."
 
     try:
         hits = _searcher.search(query, k=1)
@@ -24,7 +43,7 @@ def wiki_search(query: str) -> str:
         return contents
 
     except Exception as e:
-        return f"Error: during search: {e}"
+        return f"Error during search: {e}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some local machines won't have (or won't want to install) JDK. To allow us to probe the codebase without installing JDK, we conditionally import here!